### PR TITLE
Allow inverting authzgroup matcher

### DIFF
--- a/dist/permission-matcher.js
+++ b/dist/permission-matcher.js
@@ -1075,7 +1075,11 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
             var regex = '^' + str_replace('[^/]+', '\\*', preg_quote(pattern, '~')) + '$';
             regex = str_replace('\\*', '(.*)', regex);
             regex = new RegExp(regex, 'i');
-            return subject.match(regex);
+
+            var invert = pattern.startsWith('!');
+            var match = subject.match(regex);
+
+            return invert ? !match : match;
           }
 
           /**
@@ -1090,8 +1094,8 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
         }, {
           key: "queryParamsAreEqual",
           value: function queryParamsAreEqual(permissionAuthzGroup, authzGroup) {
-            var authzGroupQueryParams = lowerCaseObjectKeys(this.getStringQueryParameters(authzGroup), 'CASE_LOWER');
-            var permissionAuthzGroupQueryParams = lowerCaseObjectKeys(this.getStringQueryParameters(permissionAuthzGroup), 'CASE_LOWER');
+            var authzGroupQueryParams = this.lowerCaseObjectKeys(this.getStringQueryParameters(authzGroup), 'CASE_LOWER');
+            var permissionAuthzGroupQueryParams = this.lowerCaseObjectKeys(this.getStringQueryParameters(permissionAuthzGroup), 'CASE_LOWER');
             ksort(authzGroupQueryParams);
             ksort(permissionAuthzGroupQueryParams);
             return equal(permissionAuthzGroupQueryParams, authzGroupQueryParams);
@@ -1133,24 +1137,34 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
             return [].concat(_toConsumableArray(new Set(list)));
           }
+
+          /**
+           * Lowercases the keys of an object
+           *
+           * @protected
+           * @param  {object} object
+           * @return {array}
+           */
+
+        }, {
+          key: "lowerCaseObjectKeys",
+          value: function lowerCaseObjectKeys(object) {
+            var key = void 0,
+                keys = Object.keys(object);
+            var n = keys.length;
+            var newObject = {};
+
+            while (n--) {
+              key = keys[n];
+              newObject[key.toLowerCase()] = object[key];
+            }
+
+            return newObject;
+          }
         }]);
 
         return PermissionMatcher;
       }();
-
-      function lowerCaseObjectKeys(obj) {
-        var key = void 0,
-            keys = Object.keys(obj);
-        var n = keys.length;
-        var newobj = {};
-
-        while (n--) {
-          key = keys[n];
-          newobj[key.toLowerCase()] = obj[key];
-        }
-
-        return newobj;
-      }
 
       module.exports = PermissionMatcher;
     }, { "deep-equal": 1, "locutus/php/array/array_merge": 5, "locutus/php/array/ksort": 6, "locutus/php/pcre/preg_quote": 9, "locutus/php/strings/parse_str": 10, "locutus/php/strings/rtrim": 11, "locutus/php/strings/str_replace": 12, "locutus/php/strings/strtok": 14, "locutus/php/url/parse_url": 15 }] }, {}, [16])(16);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-matcher-js",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "JavaScript port of legalthings/permission-matcher",
   "main": "src/permission-matcher.js",
   "scripts": {

--- a/src/permission-matcher.js
+++ b/src/permission-matcher.js
@@ -23,10 +23,10 @@ class PermissionMatcher {
      * @return {array}
      */
     match (permissions, authzGroups) {
-        let privileges = [];
+        const privileges = [];
         
         for (let permissionAuthzGroup in permissions) {
-            let permissionPrivileges = permissions[permissionAuthzGroup];
+            const permissionPrivileges = permissions[permissionAuthzGroup];
 
             this.hasMatchingAuthzGroup(permissionAuthzGroup, authzGroups, (matches) => {
                 if (!matches) return;
@@ -77,8 +77,8 @@ class PermissionMatcher {
      * @return {boolean}
      */
     pathsAreEqual (permissionAuthzGroup, authzGroup) {
-        let permissionAuthzGroupPath = rtrim(strtok(permissionAuthzGroup, '?'), '/');
-        let authzGroupPath = rtrim(strtok(authzGroup, '?'), '/');
+        const permissionAuthzGroupPath = rtrim(strtok(permissionAuthzGroup, '?'), '/');
+        const authzGroupPath = rtrim(strtok(authzGroup, '?'), '/');
         return this.matchAuthzGroupPaths(permissionAuthzGroupPath, authzGroupPath) ||
             this.matchAuthzGroupPaths(authzGroupPath, permissionAuthzGroupPath);
     }
@@ -95,7 +95,11 @@ class PermissionMatcher {
         let regex = '^' + str_replace('[^/]+', '\\*', preg_quote(pattern, '~')) + '$';
         regex = str_replace('\\*', '(.*)', regex);
         regex = new RegExp(regex, 'i');
-        return subject.match(regex);
+        
+        const invert = pattern.startsWith('!');
+        const match = subject.match(regex);
+        
+        return invert ? !match : match;
     }
 
     /**
@@ -107,8 +111,8 @@ class PermissionMatcher {
      * @return {boolean}
      */
     queryParamsAreEqual (permissionAuthzGroup, authzGroup) {
-        let authzGroupQueryParams = lowerCaseObjectKeys(this.getStringQueryParameters(authzGroup), 'CASE_LOWER');
-        let permissionAuthzGroupQueryParams = lowerCaseObjectKeys(this.getStringQueryParameters(permissionAuthzGroup), 'CASE_LOWER');
+        let authzGroupQueryParams = this.lowerCaseObjectKeys(this.getStringQueryParameters(authzGroup), 'CASE_LOWER');
+        let permissionAuthzGroupQueryParams = this.lowerCaseObjectKeys(this.getStringQueryParameters(permissionAuthzGroup), 'CASE_LOWER');
         ksort(authzGroupQueryParams);
         ksort(permissionAuthzGroupQueryParams);
         return equal(permissionAuthzGroupQueryParams, authzGroupQueryParams);
@@ -122,8 +126,8 @@ class PermissionMatcher {
      * @return {array}
      */
     getStringQueryParameters (string) {
-        let query = parse_url(string, 'PHP_URL_QUERY');
-        let params = [];
+        const query = parse_url(string, 'PHP_URL_QUERY');
+        const params = [];
         if (query) parse_str(query, params);
         return params;
     }
@@ -144,19 +148,26 @@ class PermissionMatcher {
 
         return [...new Set(list)];
     }
-}
 
-function lowerCaseObjectKeys (obj) {
-    let key, keys = Object.keys(obj);
-    let n = keys.length;
-    let newobj = {}
+    /**
+     * Lowercases the keys of an object
+     *
+     * @protected
+     * @param  {object} object
+     * @return {array}
+     */
+    lowerCaseObjectKeys (object) {
+       let key, keys = Object.keys(object);
+       let n = keys.length;
+       let newObject = {}
 
-    while (n--) {
-        key = keys[n];
-        newobj[key.toLowerCase()] = obj[key];
+       while (n--) {
+           key = keys[n];
+           newObject[key.toLowerCase()] = object[key];
+       }
+
+       return newObject;
     }
-
-    return newobj;
 }
 
 module.exports = PermissionMatcher;

--- a/tests/unit/permission-matcher.js
+++ b/tests/unit/permission-matcher.js
@@ -15,11 +15,12 @@ describe('PermissionMatcher', function() {
         it('should match resources with query params', testMatchResourceWithQueryParams);
         it('should match resources with wildcard query params', testMatchWildcardResource);
         it('should match resources with insensitive query params', testMatchCaseInsensitiveQueryParams);
+        it('should match inverted permissions', testMatchInverted);
     });
 });
 
 function testMatchString () {
-    let permissions = {
+    const permissions = {
         'admin': 'write',
         'guest': 'read'
     };
@@ -31,7 +32,7 @@ function testMatchString () {
 }
 
 function testMatchArray () {
-    let permissions = {
+    const permissions = {
         'admin': ['read', 'write'],
         'guest': ['read'],
         'owner': ['manage']
@@ -44,7 +45,7 @@ function testMatchArray () {
 }
 
 function testMatchNested () {
-    let permissions = {
+    const permissions = {
         'admin': 'read',
         'admin.support': 'write',
         'admin.dev': 'develop'
@@ -55,7 +56,7 @@ function testMatchNested () {
 }
 
 function testMatchWildcard () {
-    let permissions = {
+    const permissions = {
         'admin': 'read',
         'admin.support': 'write',
         'admin.dev': 'develop',
@@ -76,7 +77,7 @@ function testMatchWildcard () {
 }
 
 function testMatchCaseInsensitivePath () {
-    let permissions = {
+    const permissions = {
         'AdMiN': 'read'
     };
     assert.deepEqual(matcher.match(permissions, ['admin']), ['read']);
@@ -86,7 +87,7 @@ function testMatchCaseInsensitivePath () {
 }
 
 function testMatchResource () {
-    let permissions = {
+    const permissions = {
         '/admin': 'read',
         '/admin/support': 'write',
         '/admin/dev': 'develop',
@@ -102,7 +103,7 @@ function testMatchResource () {
 }
 
 function testMatchResourceWithQueryParams () {
-    let permissions = {
+    const permissions = {
         '/admin': 'read',
         '/admin?role=support': 'write',
         '/admin?role=dev': 'develop',
@@ -118,7 +119,7 @@ function testMatchResourceWithQueryParams () {
 }
 
 function testMatchWildcardResource () {
-    let permissions = {
+    const permissions = {
         '/admin': 'read',
         '/admin/support': 'write',
         '/admin/dev': 'develop',
@@ -139,11 +140,21 @@ function testMatchWildcardResource () {
 }
 
 function testMatchCaseInsensitiveQueryParams () {
-    let permissions = {
+    const permissions = {
         '/admin?ROlE=support': 'write',
         '/admin?Job=lawyer&FROM=amsterdam': 'party'
     };
     assert.deepEqual(matcher.match(permissions, ['/admin?role=support']), ['write']);
     assert.deepEqual(matcher.match(permissions, ['/admin?RolE=support']), ['write']);
     assert.deepEqual(matcher.match(permissions, ['/admin?joB=lawyer&FroM=amsterdam']), ['party']);
+}
+
+function testMatchInverted () {
+    const permissions = {
+        '!admin': 'read',
+        'admin': ['read', 'write']
+    };
+    assert.deepEqual(matcher.match(permissions, ['admin']), ['read', 'write']);
+    assert.deepEqual(matcher.match(permissions, ['guest']), ['read']);
+    assert.deepEqual(matcher.match(permissions, ['foo']), ['read']);
 }


### PR DESCRIPTION
You can invert the result of a match by placing a ! in front of a authz group, see added test.
